### PR TITLE
Feat/db items

### DIFF
--- a/be/package.json
+++ b/be/package.json
@@ -6,7 +6,9 @@
   "scripts": {
     "test": "echo \"Error: no test specified\" && exit 1",
     "start": "node server.js",
-    "dev": "node --watch server.js"
+    "dev": "node --watch server.js",
+    "seed:items": "node scripts/seedItems.js"
+
   },
   "keywords": [],
   "author": "",

--- a/be/package.json
+++ b/be/package.json
@@ -8,7 +8,6 @@
     "start": "node server.js",
     "dev": "node --watch server.js",
     "seed:items": "node scripts/seedItems.js"
-
   },
   "keywords": [],
   "author": "",

--- a/be/scripts/seedItems.js
+++ b/be/scripts/seedItems.js
@@ -9,18 +9,14 @@ const path = require('path');
 
 const MOCK_DATA_DIR = path.resolve(__dirname, '../../be-mock/mock_data');
 
-
+// Read mock responses from disk so they can be converted into MongoDB items.
 async function readJSONFile(fileName) {
     const filePath = path.join(MOCK_DATA_DIR, fileName);
     const raw = await fs.promises.readFile(filePath, 'utf-8');
     return JSON.parse(raw);
 }
-seedItems().catch((err) => {
-    console.error(err);
-    process.exitCode = 1;
-});
 
-
+// Convert one raw mock item into the flat shape used by ItemModel.
 function normalizeItem(raw, parentId) {
     const kids = Array.isArray(raw.kids)
         ? raw.kids.map((kid) => (typeof kid === 'number' ? kid : kid.id))
@@ -49,7 +45,7 @@ function normalizeItem(raw, parentId) {
     };
 }
 
-
+// Walk nested mock comments and collect every comment as a separate DB item.
 function flattenItem(raw, parentId, result = []) {
     if (!raw || typeof raw.id !== 'number') {
         return result;
@@ -77,6 +73,8 @@ async function seedItems() {
 
     const flattened = [];
 
+    // The mock item endpoint stores data as [story, ...topLevelComments].
+    // In MongoDB, the story keeps only top-level comment ids in `kids`.
     flattened.push(
         normalizeItem({
             ...story,
@@ -109,3 +107,8 @@ async function seedItems() {
 
     await mongoose.disconnect();
 }
+
+seedItems().catch((err) => {
+    console.error(err);
+    process.exitCode = 1;
+});

--- a/be/scripts/seedItems.js
+++ b/be/scripts/seedItems.js
@@ -1,0 +1,111 @@
+const mongoose = require('mongoose');
+const dotenv = require('dotenv');
+const Item = require('../src/models/itemModel');
+
+dotenv.config();
+
+const fs = require('fs');
+const path = require('path');
+
+const MOCK_DATA_DIR = path.resolve(__dirname, '../../be-mock/mock_data');
+
+
+async function readJSONFile(fileName) {
+    const filePath = path.join(MOCK_DATA_DIR, fileName);
+    const raw = await fs.promises.readFile(filePath, 'utf-8');
+    return JSON.parse(raw);
+}
+seedItems().catch((err) => {
+    console.error(err);
+    process.exitCode = 1;
+});
+
+
+function normalizeItem(raw, parentId) {
+    const kids = Array.isArray(raw.kids)
+        ? raw.kids.map((kid) => (typeof kid === 'number' ? kid : kid.id))
+        : [];
+
+    const parts = Array.isArray(raw.parts)
+        ? raw.parts.map((part) => (typeof part === 'number' ? part : part.id))
+        : [];
+
+    return {
+        id: raw.id,
+        deleted: Boolean(raw.deleted),
+        type: raw.type || (raw.title || raw.url ? 'story' : 'comment'),
+        by: raw.by,
+        time: raw.time,
+        text: raw.text || '',
+        dead: Boolean(raw.dead),
+        parent: raw.parent ?? parentId,
+        poll: raw.poll,
+        kids,
+        url: raw.url,
+        score: raw.score || 0,
+        title: raw.title,
+        parts,
+        descendants: raw.descendants || 0,
+    };
+}
+
+
+function flattenItem(raw, parentId, result = []) {
+    if (!raw || typeof raw.id !== 'number') {
+        return result;
+    }
+
+    const normalized = normalizeItem(raw, parentId);
+    result.push(normalized);
+
+    if (Array.isArray(raw.kids)) {
+        raw.kids.forEach((kid) => {
+            if (typeof kid === 'object') {
+                flattenItem(kid, raw.id, result);
+            }
+        });
+    }
+
+    return result;
+}
+
+async function seedItems() {
+    const topStories = await readJSONFile('topstories.json');
+    const itemDetail = await readJSONFile('44057612.json');
+
+    const [story, ...comments] = itemDetail;
+
+    const flattened = [];
+
+    flattened.push(
+        normalizeItem({
+            ...story,
+            kids: comments.map((comment) => comment.id),
+        })
+    );
+
+    comments.forEach((comment) => {
+        flattenItem(comment, story.id, flattened);
+    });
+
+
+    console.log('topstories:', topStories.length);
+    console.log('item detail:', itemDetail.length);
+    console.log('flattened:', flattened.length);
+
+    await mongoose.connect(process.env.MONGO_URI);
+
+    await Item.bulkWrite(
+        flattened.map((item) => ({
+            updateOne: {
+                filter: { id: item.id },
+                update: { $set: item },
+                upsert: true,
+            },
+        }))
+    );
+
+    console.log(`Seeded ${flattened.length} items`);
+
+    await mongoose.disconnect();
+}

--- a/be/src/controller/storiesController.js
+++ b/be/src/controller/storiesController.js
@@ -1,6 +1,6 @@
 const storiesService = require('../services/storiesService');
 
-const STORY_TYPES = new Set(['story', 'ask', 'show', 'job', 'poll']);
+const CREATABLE_STORY_TYPES = new Set(['story', 'job', 'poll']);
 const FEED_TYPES = new Set(['top', 'new', 'best', 'ask', 'show', 'job']);
 
 async function getStories(req, res) {
@@ -45,10 +45,9 @@ function createStory(req, res) {
     return res.status(400).json({ message: 'Title is required' });
   }
 
-  if (!STORY_TYPES.has(type)) {
+  if (!CREATABLE_STORY_TYPES.has(type)) {
     return res.status(400).json({ message: 'Invalid story type' });
   }
-
   if (!url && !text) {
     return res.status(400).json({ message: 'Either url or text is required' });
   }

--- a/be/src/controller/storiesController.js
+++ b/be/src/controller/storiesController.js
@@ -1,15 +1,7 @@
-const fs = require('fs/promises');
-const path = require('path');
+const storiesService = require('../services/storiesService');
 
-const MOCK_DATA_DIR = path.resolve(__dirname, '../../../be-mock/mock_data');
 const STORY_TYPES = new Set(['story', 'ask', 'show', 'job', 'poll']);
 const FEED_TYPES = new Set(['top', 'new', 'best', 'ask', 'show', 'job']);
-
-async function readMockJson(fileName) {
-  const filePath = path.join(MOCK_DATA_DIR, fileName);
-  const raw = await fs.readFile(filePath, 'utf8');
-  return JSON.parse(raw);
-}
 
 async function getStories(req, res) {
   const { type } = req.params;
@@ -19,26 +11,30 @@ async function getStories(req, res) {
 
   const limit = Math.min(Math.max(parseInt(req.query.limit, 10) || 30, 1), 100);
   const page = Math.max(parseInt(req.query.page, 10) || 1, 1);
-  const offset = (page - 1) * limit;
 
   try {
-    // Mock data only has topstories; reuse for all feed types until real data lands.
-    const all = await readMockJson('topstories.json');
-    const items = (Array.isArray(all) ? all : []).slice(offset, offset + limit);
-    return res.json({ type, page, count: items.length, items });
+    const stories = await storiesService.getStories(type, page, limit);
+    return res.json(stories);
   } catch (err) {
     return res.status(500).json({ message: 'Failed to read stories' });
   }
 }
 
 async function getItem(req, res) {
+  const id = parseInt(req.params.id, 10);
+  if (!Number.isFinite(id)) {
+    return res.status(400).json({ message: 'Invalid item id' });
+  }
+
   try {
-    const data = await readMockJson(`${req.params.id}.json`);
-    // Mock stores items as [story, ...comments]; pass through under { item } envelope.
-    const item = Array.isArray(data) ? data : [data];
-    return res.json({ item });
+    const item = await storiesService.getItemWithComments(id);
+    if (!item) {
+      return res.status(404).json({ message: `Item ${req.params.id} not found` });
+    }
+
+    return res.json(item);
   } catch (err) {
-    return res.status(404).json({ message: `Item ${req.params.id} not found` });
+    return res.status(500).json({ message: 'Failed to read item' });
   }
 }
 

--- a/be/src/models/itemModel.js
+++ b/be/src/models/itemModel.js
@@ -1,0 +1,96 @@
+const mongoose = require('mongoose');
+
+const ITEM_TYPES = ['job', 'story', 'comment', 'poll', 'pollopt'];
+
+const ItemSchema = new mongoose.Schema(
+    {
+        id: {
+            type: Number,
+            required: true,
+            unique: true,
+            index: true,
+        },
+
+        deleted: {
+            type: Boolean,
+            default: false,
+        },
+
+        type: {
+            type: String,
+            enum: ITEM_TYPES,
+            required: true,
+            index: true,
+        },
+
+        by: {
+            type: String,
+            trim: true,
+            index: true,
+        },
+
+        time: {
+            type: Number,
+            index: true,
+        },
+
+        text: {
+            type: String,
+            default: '',
+        },
+
+        dead: {
+            type: Boolean,
+            default: false,
+        },
+
+        parent: {
+            type: Number,
+            index: true,
+        },
+
+        poll: {
+            type: Number,
+        },
+
+        kids: {
+            type: [Number],
+            default: [],
+        },
+
+        url: {
+            type: String,
+            trim: true,
+        },
+
+        score: {
+            type: Number,
+            default: 0,
+            index: true,
+        },
+
+        title: {
+            type: String,
+            trim: true,
+        },
+
+        parts: {
+            type: [Number],
+            default: [],
+        },
+
+        descendants: {
+            type: Number,
+            default: 0,
+        },
+    },
+    { timestamps: true }
+);
+
+ItemSchema.index({ type: 1, score: -1, time: -1 });
+ItemSchema.index({ parent: 1, time: 1 });
+
+const Item = mongoose.model('Item', ItemSchema);
+
+module.exports = Item;
+module.exports.ITEM_TYPES = ITEM_TYPES;

--- a/be/src/models/itemModel.js
+++ b/be/src/models/itemModel.js
@@ -2,6 +2,8 @@ const mongoose = require('mongoose');
 
 const ITEM_TYPES = ['job', 'story', 'comment', 'poll', 'pollopt'];
 
+// Stores every Hacker News entity in one collection. The `type` field tells
+// whether a document is a story, comment, job, poll, or poll option.
 const ItemSchema = new mongoose.Schema(
     {
         id: {
@@ -54,6 +56,8 @@ const ItemSchema = new mongoose.Schema(
         },
 
         kids: {
+            // Store child item ids in MongoDB. API services expand these ids
+            // into nested objects before sending data to the frontend.
             type: [Number],
             default: [],
         },
@@ -87,6 +91,7 @@ const ItemSchema = new mongoose.Schema(
     { timestamps: true }
 );
 
+// Feed and comment-tree queries depend on these common access patterns.
 ItemSchema.index({ type: 1, score: -1, time: -1 });
 ItemSchema.index({ parent: 1, time: 1 });
 

--- a/be/src/routes/storiesRoutes.js
+++ b/be/src/routes/storiesRoutes.js
@@ -10,7 +10,7 @@ router.get('/stories/:type', storiesController.getStories);
 
 // Write endpoints (PR21 shape, auth-gated)
 router.post('/stories', auth, storiesController.createStory);
-router.post('/stories/:id/comment', auth, storiesController.createComment);
+router.post('/stories/:id/comments', auth, storiesController.createComment);
 router.put('/stories/:id/vote', auth, storiesController.voteStory);
 router.delete('/stories/:id', auth, storiesController.deleteStory);
 

--- a/be/src/services/storiesService.js
+++ b/be/src/services/storiesService.js
@@ -1,0 +1,103 @@
+const Item = require('../models/itemModel');
+
+// Translate a feed name from the route into a MongoDB query.
+function getFeedQuery(type) {
+    if (type === 'job') {
+        return { type: 'job', deleted: false, dead: false };
+    }
+
+    if (type === 'ask') {
+        return {
+            type: 'story',
+            deleted: false,
+            dead: false,
+            title: /^Ask HN/i,
+        };
+    }
+
+    if (type === 'show') {
+        return {
+            type: 'story',
+            deleted: false,
+            dead: false,
+            title: /^Show HN/i,
+        };
+    }
+
+    return {
+        type: 'story',
+        deleted: false,
+        dead: false,
+    };
+}
+
+// Keep feed ordering in one place so controllers do not know query details.
+function getFeedSort(type) {
+    if (type === 'new') {
+        return { time: -1 };
+    }
+
+    return { score: -1, time: -1 };
+}
+
+// Return one paginated feed using the same response envelope as the mock API.
+async function getStories(type, page = 1, limit = 30) {
+    const offset = (page - 1) * limit;
+
+    const items = await Item.find(getFeedQuery(type))
+        .sort(getFeedSort(type))
+        .skip(offset)
+        .limit(limit)
+        .lean();
+
+    return {
+        type,
+        page,
+        count: items.length,
+        items,
+    };
+}
+
+// Expand child ids into nested comment objects for the frontend comment page.
+async function buildCommentTree(ids = []) {
+    if (!ids.length) return [];
+
+    const comments = await Item.find({ id: { $in: ids } }).lean();
+    const byId = new Map(comments.map((comment) => [comment.id, comment]));
+
+    return Promise.all(
+        ids
+            .map((id) => byId.get(id))
+            .filter(Boolean)
+            .map(async (comment) => ({
+                ...comment,
+                kids: await buildCommentTree(comment.kids || []),
+            }))
+    );
+}
+
+// Return the story and its top-level comments in the shape currently used by FE.
+async function getItemWithComments(id) {
+    const story = await Item.findOne({ id }).lean();
+
+    if (!story) {
+        return null;
+    }
+
+    const comments = await buildCommentTree(story.kids || []);
+
+    return {
+        item: [
+            {
+                ...story,
+                kids: story.kids || [],
+            },
+            ...comments,
+        ],
+    };
+}
+
+module.exports = {
+    getStories,
+    getItemWithComments,
+};

--- a/fe/src/types/hnItem.ts
+++ b/fe/src/types/hnItem.ts
@@ -1,15 +1,19 @@
-export interface hnItem{
+export interface hnItem {
     id: number;
-    type: "job" | "story" | "comment" | "poll";
+    deleted?: boolean;
+    type: 'job' | 'story' | 'comment' | 'poll' | 'pollopt';
     by?: string;
     time: number;
     text?: string;
     dead?: boolean;
     parent?: number;
-    //poll không rõ
+    poll?: number;
+    // API responses expand kids into nested item objects.
+    // The database stores kids as numeric ids.
     kids?: hnItem[];
     url?: string;
     score?: number;
     title?: string;
+    parts?: number[];
     descendants?: number;
 }


### PR DESCRIPTION
Thêm nền tảng database cho item và chuyển phần read API sang đọc dữ liệu qua service layer.

- Thêm `ItemModel` cho collection `items`.
- Thêm script seed mock data vào MongoDB.
- Thêm `storiesService` để query stories và build comment tree từ DB.
- Cập nhật controller để dùng service cho các read endpoints.
- Giữ response shape giống `be-mock` để frontend không cần đổi lớn.

- `kids` được lưu trong DB dưới dạng id array.
- Service sẽ expand `kids` thành nested comments khi trả về frontend.
- Write endpoints hiện vẫn là placeholder và sẽ xử lý ở bước sau.
<img width="724" height="85" alt="image" src="https://github.com/user-attachments/assets/266f7197-215d-495a-8911-defa92e8c2b9" />
<img width="1438" height="471" alt="image" src="https://github.com/user-attachments/assets/e4c5bc6c-a8e4-4708-bf67-a347fd761c6a" />
<img width="1425" height="546" alt="image" src="https://github.com/user-attachments/assets/83f03cc7-e09e-4de2-90b1-ac1fa78ba0be" />
<img width="1321" height="525" alt="image" src="https://github.com/user-attachments/assets/aaac74b9-76f9-4c31-a58c-d863a0a37a35" />
<img width="1429" height="832" alt="image" src="https://github.com/user-attachments/assets/224dfbab-593b-46c5-9d1a-9a997941b646" />


