### PR TITLE
feat(be): authorization, edit window, soft-delete with masking (#35)

### DIFF
--- a/be/scripts/seedFromHN.js
+++ b/be/scripts/seedFromHN.js
@@ -12,7 +12,12 @@ const FEED_TO_ENDPOINT = {
   show: 'showstories',
   job: 'jobstories',
 };
-const MAX_COMMENT_DEPTH = 6;
+// Keep the tree shallow + narrow. Real HN threads have 600+ deep comments
+// which bloat the DB and slow the read path. Migration to ObjectId refs
+// (scripts/migrateToObjectId.js) runs after seeding, so the saved numeric
+// id / parent / kids stay as Numbers until then.
+const MAX_COMMENT_DEPTH = 2;
+const MAX_COMMENTS_PER_ITEM = 5;
 
 async function fetchJson(url) {
   const res = await fetch(url);
@@ -44,7 +49,14 @@ function toDoc(data) {
 
 async function upsertItem(data) {
   const doc = toDoc(data);
-  await Item.updateOne({ id: doc.id }, { $set: doc }, { upsert: true });
+  // Raw collection write bypasses Mongoose strict mode so numeric `id`,
+  // `parent`, and `kids` persist as Numbers until migrateToObjectId.js
+  // rewrites them into ObjectId refs.
+  await Item.collection.updateOne(
+    { id: doc.id },
+    { $set: doc, $setOnInsert: { createdAt: new Date() } },
+    { upsert: true }
+  );
   return doc;
 }
 
@@ -65,7 +77,8 @@ async function walkItem(id, depth, seen, withComments) {
     return;
   }
 
-  for (const kidId of data.kids) {
+  const limitedKids = data.kids.slice(0, MAX_COMMENTS_PER_ITEM);
+  for (const kidId of limitedKids) {
     try {
       await walkItem(kidId, depth + 1, seen, withComments);
     } catch (err) {
@@ -79,6 +92,7 @@ async function seedFromHN() {
   const count = parseInt(args[0], 10) || 10;
   const feedArg = (args[1] || 'top').toLowerCase();
   const withComments = !args.includes('--no-comments');
+  const reset = args.includes('--reset');
   const feedEndpoint = FEED_TO_ENDPOINT[feedArg];
 
   if (!feedEndpoint) {
@@ -92,6 +106,11 @@ async function seedFromHN() {
   }
 
   await mongoose.connect(process.env.MONGO_URI);
+
+  if (reset) {
+    const { deletedCount } = await Item.collection.deleteMany({});
+    console.log(`--reset: dropped ${deletedCount} existing items`);
+  }
 
   const ids = await fetchJson(`${HN_BASE}/${feedEndpoint}.json`);
   const targetIds = (Array.isArray(ids) ? ids : []).slice(0, count);

--- a/be/src/controller/storiesController.js
+++ b/be/src/controller/storiesController.js
@@ -97,12 +97,37 @@ function voteStory(req, res) {
   });
 }
 
-function deleteStory(req, res) {
-  return res.json({
-    message: 'Delete story placeholder. Enforce author/admin ownership in the database later.',
-    storyId: Number(req.params.id),
-    deleted: true,
-  });
+async function deleteStory(req, res) {
+  try {
+    const result = await storiesService.deleteItem({
+      itemId: req.params.id,
+      actor: req.user,
+    });
+    return res.json(result);
+  } catch (err) {
+    if (err instanceof storiesService.StoriesServiceError) {
+      return res.status(err.status).json({ message: err.message, code: err.code });
+    }
+    console.error('[DeleteStory Error]:', err);
+    return res.status(500).json({ message: 'Failed to delete item' });
+  }
+}
+
+async function editItem(req, res) {
+  try {
+    const item = await storiesService.editItem({
+      itemId: req.params.id,
+      updates: req.body || {},
+      actor: req.user,
+    });
+    return res.json(item);
+  } catch (err) {
+    if (err instanceof storiesService.StoriesServiceError) {
+      return res.status(err.status).json({ message: err.message, code: err.code });
+    }
+    console.error('[EditItem Error]:', err);
+    return res.status(500).json({ message: 'Failed to edit item' });
+  }
 }
 
 module.exports = {
@@ -112,4 +137,5 @@ module.exports = {
   createComment,
   voteStory,
   deleteStory,
+  editItem,
 };

--- a/be/src/models/itemModel.js
+++ b/be/src/models/itemModel.js
@@ -83,6 +83,17 @@ const ItemSchema = new mongoose.Schema(
             type: Number,
             default: 0,
         },
+
+        editedBy: {
+            type: mongoose.Schema.Types.ObjectId,
+            ref: 'User',
+            default: null,
+        },
+
+        editedAt: {
+            type: Date,
+            default: null,
+        },
     },
     { timestamps: true }
 );

--- a/be/src/routes/storiesRoutes.js
+++ b/be/src/routes/storiesRoutes.js
@@ -13,5 +13,11 @@ router.post('/stories', auth, storiesController.createStory);
 router.post('/comments', auth, storiesController.createComment);
 router.put('/stories/:id/vote', auth, storiesController.voteStory);
 router.delete('/stories/:id', auth, storiesController.deleteStory);
+router.delete('/items/:id', auth, storiesController.deleteStory);
+// PATCH for partial updates (text/title/url). Items can be stories or
+// comments, so the same handler covers all three aliases.
+router.patch('/stories/:id', auth, storiesController.editItem);
+router.patch('/items/:id', auth, storiesController.editItem);
+router.patch('/comments/:id', auth, storiesController.editItem);
 
 module.exports = router;

--- a/be/src/services/storiesService.js
+++ b/be/src/services/storiesService.js
@@ -2,6 +2,39 @@ const Item = require('../models/itemModel');
 const mongoose = require('mongoose');
 
 const MAX_COMMENT_DEPTH = 6;
+const EDIT_WINDOW_SECONDS = 2 * 60 * 60; // 2 hours
+const EDITABLE_FIELDS = new Set(['text', 'title', 'url']);
+
+class StoriesServiceError extends Error {
+    constructor(message, code = 'STORIES_ERROR', status = 400) {
+        super(message);
+        this.code = code;
+        this.status = status;
+    }
+}
+
+// Replace author/text on deleted items so the FE shows "[deleted]" while the
+// comment tree shape (parent/child relationships) stays intact.
+function maskDeleted(item) {
+    if (!item) return item;
+    if (item.deleted) {
+        return { ...item, by: '[deleted]', text: '[deleted]', url: '', title: '' };
+    }
+    return item;
+}
+
+// Owner = original author (by username). Admin always allowed.
+function canMutate(item, actor) {
+    if (!actor) return false;
+    if (actor.role === 'admin') return true;
+    return Boolean(actor.username) && item.by === actor.username;
+}
+
+function isWithinEditWindow(item) {
+    if (!item.time) return false;
+    const nowSec = Math.floor(Date.now() / 1000);
+    return nowSec - item.time <= EDIT_WINDOW_SECONDS;
+}
 
 // Translate a feed name from the route into a MongoDB query.
 function getFeedQuery(type) {
@@ -57,7 +90,7 @@ async function getStories(type, page = 1, limit = 30) {
         type,
         page,
         count: items.length,
-        items,
+        items: items.map(maskDeleted),
     };
 }
 
@@ -68,9 +101,10 @@ async function buildCommentTree(rootId) {
     let depth = 0;
 
     while (frontier.length > 0 && depth < MAX_COMMENT_DEPTH) {
+        // Keep deleted items in the tree so child references survive;
+        // masking is applied at the response layer.
         const level = await Item.find({
             parent: { $in: frontier },
-            deleted: { $ne: true },
             dead: { $ne: true },
         })
             .sort({ time: 1 })
@@ -81,7 +115,7 @@ async function buildCommentTree(rootId) {
         }
 
         for (const comment of level) {
-            byId.set(comment._id.toString(), { ...comment, kids: [] });
+            byId.set(comment._id.toString(), { ...maskDeleted(comment), kids: [] });
         }
 
         frontier = level.map((comment) => comment._id);
@@ -114,15 +148,13 @@ async function getItemWithComments(id) {
     }
 
     const comments = await buildCommentTree(story._id);
+    const maskedStory = maskDeleted({
+        ...story,
+        kids: story.kids || [],
+    });
 
     return {
-        item: [
-            {
-                ...story,
-                kids: story.kids || [],
-            },
-            ...comments,
-        ],
+        item: [maskedStory, ...comments],
     };
 }
 
@@ -167,9 +199,102 @@ async function createComment(data) {
     return savedComment;
 }
 
+/**
+ * Soft-delete an item. Content fields are blanked at the response layer via
+ * maskDeleted; the document itself is preserved so the comment tree's
+ * parent/child relationships remain intact.
+ */
+async function deleteItem({ itemId, actor }) {
+    if (!mongoose.isValidObjectId(itemId)) {
+        throw new StoriesServiceError('Invalid item id', 'INVALID_ITEM_ID', 400);
+    }
+
+    const item = await Item.findById(itemId);
+    if (!item) {
+        throw new StoriesServiceError('Item not found', 'ITEM_NOT_FOUND', 404);
+    }
+
+    if (item.deleted) {
+        return { ok: true, alreadyDeleted: true, itemId: item._id };
+    }
+
+    if (!canMutate(item, actor)) {
+        throw new StoriesServiceError('Forbidden', 'FORBIDDEN', 403);
+    }
+
+    if (!isWithinEditWindow(item)) {
+        throw new StoriesServiceError(
+            `Modifications are only allowed within ${EDIT_WINDOW_SECONDS / 3600} hours of creation`,
+            'EDIT_WINDOW_EXPIRED',
+            400
+        );
+    }
+
+    item.deleted = true;
+    await item.save();
+
+    return { ok: true, itemId: item._id, deleted: true };
+}
+
+/**
+ * Edit whitelisted fields on an item. Requires owner or admin actor,
+ * and creation timestamp within the edit window. Stamps editedBy/editedAt.
+ */
+async function editItem({ itemId, updates, actor }) {
+    if (!mongoose.isValidObjectId(itemId)) {
+        throw new StoriesServiceError('Invalid item id', 'INVALID_ITEM_ID', 400);
+    }
+
+    const item = await Item.findById(itemId);
+    if (!item) {
+        throw new StoriesServiceError('Item not found', 'ITEM_NOT_FOUND', 404);
+    }
+
+    if (item.deleted) {
+        throw new StoriesServiceError('Cannot edit a deleted item', 'ITEM_DELETED', 400);
+    }
+
+    if (!canMutate(item, actor)) {
+        throw new StoriesServiceError('Forbidden', 'FORBIDDEN', 403);
+    }
+
+    if (!isWithinEditWindow(item)) {
+        throw new StoriesServiceError(
+            `Edit window expired (${EDIT_WINDOW_SECONDS / 3600}h after creation)`,
+            'EDIT_WINDOW_EXPIRED',
+            400
+        );
+    }
+
+    const sanitized = {};
+    for (const [key, value] of Object.entries(updates || {})) {
+        if (EDITABLE_FIELDS.has(key) && typeof value === 'string') {
+            sanitized[key] = value;
+        }
+    }
+
+    if (Object.keys(sanitized).length === 0) {
+        throw new StoriesServiceError(
+            `No editable fields supplied (allowed: ${[...EDITABLE_FIELDS].join(', ')})`,
+            'NO_EDITABLE_FIELDS',
+            400
+        );
+    }
+
+    Object.assign(item, sanitized);
+    item.editedBy = actor.id;
+    item.editedAt = new Date();
+    await item.save();
+
+    return item.toObject();
+}
+
 module.exports = {
     getStories,
     getItemWithComments,
     createStory,
     createComment,
+    deleteItem,
+    editItem,
+    StoriesServiceError,
 };

--- a/be/tests/authorization.test.js
+++ b/be/tests/authorization.test.js
@@ -1,0 +1,285 @@
+const mongoose = require('mongoose');
+const dbHandler = require('./db-handler');
+const storiesService = require('../src/services/storiesService');
+const Item = require('../src/models/itemModel');
+
+beforeAll(async () => await dbHandler.connect());
+afterEach(async () => await dbHandler.clearDatabase());
+afterAll(async () => await dbHandler.closeDatabase());
+
+// time is seconds-since-epoch in the HN model. Helpers below build items
+// that look "fresh" (within the 2h edit window) or "stale" (older).
+function nowSec() {
+    return Math.floor(Date.now() / 1000);
+}
+function staleSec() {
+    return nowSec() - 60 * 60 * 3; // 3 hours ago
+}
+
+async function makeStory(overrides = {}) {
+    const story = new Item({
+        title: 'Auth test story',
+        type: 'story',
+        by: 'alice',
+        time: nowSec(),
+        ...overrides,
+    });
+    return await story.save();
+}
+
+const aliceActor = { id: new mongoose.Types.ObjectId(), username: 'alice', role: 'user' };
+const bobActor = { id: new mongoose.Types.ObjectId(), username: 'bob', role: 'user' };
+const adminActor = { id: new mongoose.Types.ObjectId(), username: 'mallory', role: 'admin' };
+
+describe('storiesService.deleteItem', () => {
+    it('soft-deletes when called by the owner within the edit window', async () => {
+        const story = await makeStory();
+
+        const result = await storiesService.deleteItem({
+            itemId: story._id,
+            actor: aliceActor,
+        });
+
+        expect(result).toMatchObject({ ok: true, deleted: true });
+
+        const reloaded = await Item.findById(story._id);
+        expect(reloaded.deleted).toBe(true);
+        // Soft delete: the document is preserved.
+        expect(reloaded.title).toBe('Auth test story');
+    });
+
+    it('refuses with FORBIDDEN when actor is not the owner and not admin', async () => {
+        const story = await makeStory();
+
+        await expect(
+            storiesService.deleteItem({ itemId: story._id, actor: bobActor })
+        ).rejects.toMatchObject({ code: 'FORBIDDEN', status: 403 });
+
+        const reloaded = await Item.findById(story._id);
+        expect(reloaded.deleted).toBe(false);
+    });
+
+    it('allows admin to delete any item regardless of owner', async () => {
+        const story = await makeStory({ by: 'someone-else' });
+
+        const result = await storiesService.deleteItem({
+            itemId: story._id,
+            actor: adminActor,
+        });
+
+        expect(result.deleted).toBe(true);
+    });
+
+    it('returns EDIT_WINDOW_EXPIRED for items older than 2 hours', async () => {
+        const story = await makeStory({ time: staleSec() });
+
+        await expect(
+            storiesService.deleteItem({ itemId: story._id, actor: aliceActor })
+        ).rejects.toMatchObject({ code: 'EDIT_WINDOW_EXPIRED', status: 400 });
+    });
+
+    it('is idempotent: second delete on already-deleted item returns alreadyDeleted', async () => {
+        const story = await makeStory({ deleted: true });
+
+        const result = await storiesService.deleteItem({
+            itemId: story._id,
+            actor: aliceActor,
+        });
+
+        expect(result).toMatchObject({ ok: true, alreadyDeleted: true });
+    });
+
+    it('throws INVALID_ITEM_ID on a non-ObjectId id', async () => {
+        await expect(
+            storiesService.deleteItem({ itemId: 'not-an-id', actor: aliceActor })
+        ).rejects.toMatchObject({ code: 'INVALID_ITEM_ID', status: 400 });
+    });
+
+    it('throws ITEM_NOT_FOUND when the item does not exist', async () => {
+        await expect(
+            storiesService.deleteItem({
+                itemId: new mongoose.Types.ObjectId(),
+                actor: aliceActor,
+            })
+        ).rejects.toMatchObject({ code: 'ITEM_NOT_FOUND', status: 404 });
+    });
+});
+
+describe('storiesService.editItem', () => {
+    it('edits whitelisted fields and stamps editedBy/editedAt', async () => {
+        const story = await makeStory({ title: 'Old', text: '' });
+        const before = Date.now();
+
+        const result = await storiesService.editItem({
+            itemId: story._id,
+            updates: { title: 'New title', text: 'New body' },
+            actor: aliceActor,
+        });
+
+        expect(result.title).toBe('New title');
+        expect(result.text).toBe('New body');
+        expect(String(result.editedBy)).toBe(String(aliceActor.id));
+        expect(new Date(result.editedAt).getTime()).toBeGreaterThanOrEqual(before);
+    });
+
+    it('ignores non-whitelisted fields (score, by, parent) silently', async () => {
+        const story = await makeStory({ score: 5, by: 'alice' });
+
+        const result = await storiesService.editItem({
+            itemId: story._id,
+            updates: { title: 'Renamed', score: 9999, by: 'attacker' },
+            actor: aliceActor,
+        });
+
+        expect(result.title).toBe('Renamed');
+        expect(result.score).toBe(5);
+        expect(result.by).toBe('alice');
+    });
+
+    it('rejects FORBIDDEN when actor is not owner', async () => {
+        const story = await makeStory();
+
+        await expect(
+            storiesService.editItem({
+                itemId: story._id,
+                updates: { title: 'Hijacked' },
+                actor: bobActor,
+            })
+        ).rejects.toMatchObject({ code: 'FORBIDDEN', status: 403 });
+    });
+
+    it('allows admin to edit anyone item', async () => {
+        const story = await makeStory({ by: 'someone-else' });
+
+        const result = await storiesService.editItem({
+            itemId: story._id,
+            updates: { title: 'Mod edit' },
+            actor: adminActor,
+        });
+
+        expect(result.title).toBe('Mod edit');
+        expect(String(result.editedBy)).toBe(String(adminActor.id));
+    });
+
+    it('rejects EDIT_WINDOW_EXPIRED for items older than 2 hours', async () => {
+        const story = await makeStory({ time: staleSec() });
+
+        await expect(
+            storiesService.editItem({
+                itemId: story._id,
+                updates: { title: 'Late edit' },
+                actor: aliceActor,
+            })
+        ).rejects.toMatchObject({ code: 'EDIT_WINDOW_EXPIRED', status: 400 });
+    });
+
+    it('rejects ITEM_DELETED when item is already soft-deleted', async () => {
+        const story = await makeStory({ deleted: true });
+
+        await expect(
+            storiesService.editItem({
+                itemId: story._id,
+                updates: { title: 'Resurrect' },
+                actor: aliceActor,
+            })
+        ).rejects.toMatchObject({ code: 'ITEM_DELETED', status: 400 });
+    });
+
+    it('rejects NO_EDITABLE_FIELDS when only non-whitelisted fields supplied', async () => {
+        const story = await makeStory();
+
+        await expect(
+            storiesService.editItem({
+                itemId: story._id,
+                updates: { score: 100 },
+                actor: aliceActor,
+            })
+        ).rejects.toMatchObject({ code: 'NO_EDITABLE_FIELDS', status: 400 });
+    });
+
+    it('rejects non-string values for editable fields', async () => {
+        const story = await makeStory();
+
+        await expect(
+            storiesService.editItem({
+                itemId: story._id,
+                updates: { title: 12345, text: { hack: true } },
+                actor: aliceActor,
+            })
+        ).rejects.toMatchObject({ code: 'NO_EDITABLE_FIELDS' });
+    });
+
+    it('throws INVALID_ITEM_ID on a non-ObjectId id', async () => {
+        await expect(
+            storiesService.editItem({
+                itemId: 'not-an-id',
+                updates: { title: 'x' },
+                actor: aliceActor,
+            })
+        ).rejects.toMatchObject({ code: 'INVALID_ITEM_ID', status: 400 });
+    });
+
+    it('throws ITEM_NOT_FOUND when the item is missing', async () => {
+        await expect(
+            storiesService.editItem({
+                itemId: new mongoose.Types.ObjectId(),
+                updates: { title: 'x' },
+                actor: aliceActor,
+            })
+        ).rejects.toMatchObject({ code: 'ITEM_NOT_FOUND', status: 404 });
+    });
+});
+
+describe('soft-delete masking in read paths', () => {
+    it('omits deleted stories from getStories feed', async () => {
+        await makeStory({ title: 'Alive story', score: 10 });
+        await makeStory({ title: 'Dead story', score: 5, deleted: true, by: 'ghost' });
+
+        const feed = await storiesService.getStories('top', 1, 50);
+        const titles = feed.items.map((i) => i.title);
+
+        expect(titles).toContain('Alive story');
+        expect(titles).not.toContain('Dead story');
+    });
+
+    it('keeps deleted comments in the tree under getItemWithComments and masks them', async () => {
+        const story = await makeStory();
+        const deletedComment = await new Item({
+            type: 'comment',
+            parent: story._id,
+            by: 'ghost',
+            text: 'will be removed',
+            time: nowSec(),
+            deleted: true,
+        }).save();
+        // Reply under a deleted comment must still be reachable.
+        await new Item({
+            type: 'comment',
+            parent: deletedComment._id,
+            by: 'survivor',
+            text: 'I am still here',
+            time: nowSec(),
+        }).save();
+
+        const result = await storiesService.getItemWithComments(story._id);
+        const dead = result.item.find((n) => String(n._id) === String(deletedComment._id));
+
+        expect(dead).toBeDefined();
+        expect(dead.by).toBe('[deleted]');
+        expect(dead.text).toBe('[deleted]');
+        // Child preserved on the masked parent.
+        expect(dead.kids).toHaveLength(1);
+        expect(dead.kids[0].text).toBe('I am still here');
+        expect(dead.kids[0].by).toBe('survivor');
+    });
+
+    it('does not mask non-deleted items', async () => {
+        await makeStory({ title: 'Untouched', by: 'alice' });
+
+        const feed = await storiesService.getStories('top', 1, 50);
+        const item = feed.items.find((i) => i.title === 'Untouched');
+
+        expect(item.by).toBe('alice');
+        expect(item.title).toBe('Untouched');
+    });
+});


### PR DESCRIPTION
- itemModel: add editedBy (User ref) + editedAt (Date) audit fields
- storiesService:
  - canMutate: owner (by === actor.username) or admin role
  - isWithinEditWindow: 2-hour modification window from item.time
  - maskDeleted: replace by/text/title/url with "[deleted]" while
    preserving tree shape
  - deleteItem: soft-delete with auth + window enforcement
  - editItem: whitelist text/title/url, stamp editedBy/editedAt
  - getStories/getItemWithComments: apply maskDeleted to responses
  - buildCommentTree: keep deleted nodes in tree (mask at output)
- routes: PATCH /stories|items|comments/:id, DELETE /items/:id alias
- controller: wire deleteStory + new editItem to service errors

- seedFromHN: cap comment tree at depth 2 + 5 children per node so a
  fresh seed produces ~13 items per story instead of 600+
- seedFromHN: switch to raw Item.collection writes so numeric id /
  parent / kids persist for migrateToObjectId.js to convert
- seedFromHN: add --reset flag to drop the items collection before
  reseeding