### PR TITLE
feat: add structured backend logging ( #40)

### DIFF
--- a/be/package-lock.json
+++ b/be/package-lock.json
@@ -15,11 +15,14 @@
         "dotenv": "^17.2.3",
         "express": "^5.2.1",
         "jsonwebtoken": "^9.0.3",
-        "mongoose": "^9.0.2"
+        "mongoose": "^9.0.2",
+        "pino": "^10.3.1",
+        "pino-http": "^11.0.0"
       },
       "devDependencies": {
         "jest": "^30.4.2",
         "mongodb-memory-server": "^11.2.0",
+        "pino-pretty": "^13.1.3",
         "supertest": "^7.2.2"
       }
     },
@@ -1060,6 +1063,12 @@
         "@noble/hashes": "^1.1.5"
       }
     },
+    "node_modules/@pinojs/redact": {
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/@pinojs/redact/-/redact-0.4.0.tgz",
+      "integrity": "sha512-k2ENnmBugE/rzQfEcdWHcCY+/FM3VLzH9cYEsbdsoqrvzAKRhUZeRNhAZvB8OitQJ1TBed3yqWtdjzS6wJKBwg==",
+      "license": "MIT"
+    },
     "node_modules/@pkgjs/parseargs": {
       "version": "0.11.0",
       "resolved": "https://registry.npmjs.org/@pkgjs/parseargs/-/parseargs-0.11.0.tgz",
@@ -1722,6 +1731,15 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/atomic-sleep": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/atomic-sleep/-/atomic-sleep-1.0.0.tgz",
+      "integrity": "sha512-kNOjDqAh7px0XWNI+4QbzoiR/nTkHAWNud2uvnJquD1/x5a7EQZMJT0AczqK0Qn67oY/TTQ1LbUKajZpp3I9tQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=8.0.0"
+      }
+    },
     "node_modules/b4a": {
       "version": "1.8.1",
       "resolved": "https://registry.npmjs.org/b4a/-/b4a-1.8.1.tgz",
@@ -2322,6 +2340,13 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/colorette": {
+      "version": "2.0.20",
+      "resolved": "https://registry.npmjs.org/colorette/-/colorette-2.0.20.tgz",
+      "integrity": "sha512-IfEDxwoWIjkeXL1eXcDiow4UbKjhLdq6/EuSVR9GMN7KVH3r9gQ83e73hsz1Nd1T3ijd5xv1wcWRYO+D6kCI2w==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/combined-stream": {
       "version": "1.0.8",
       "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.8.tgz",
@@ -2443,6 +2468,16 @@
       },
       "engines": {
         "node": ">= 8"
+      }
+    },
+    "node_modules/dateformat": {
+      "version": "4.6.3",
+      "resolved": "https://registry.npmjs.org/dateformat/-/dateformat-4.6.3.tgz",
+      "integrity": "sha512-2P0p0pFGzHS5EMnhdxQi7aJN+iMheud0UhG4dlE1DLAlvL8JHjJJTX/CSm4JXwV0Ka5nGk3zC5mcb5bUQUxxMA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "*"
       }
     },
     "node_modules/debug": {
@@ -2609,6 +2644,16 @@
       "license": "MIT",
       "engines": {
         "node": ">= 0.8"
+      }
+    },
+    "node_modules/end-of-stream": {
+      "version": "1.4.5",
+      "resolved": "https://registry.npmjs.org/end-of-stream/-/end-of-stream-1.4.5.tgz",
+      "integrity": "sha512-ooEGc6HP26xXq/N+GCGOT0JKCLDGrq2bQUZrQ7gyrJiZANJ/8YDTxTpQBXGMn+WbIQXNVpyWymm7KYVICQnyOg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "once": "^1.4.0"
       }
     },
     "node_modules/error-ex": {
@@ -2827,6 +2872,13 @@
         "type": "opencollective",
         "url": "https://opencollective.com/express"
       }
+    },
+    "node_modules/fast-copy": {
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/fast-copy/-/fast-copy-4.0.3.tgz",
+      "integrity": "sha512-58apWr0GUiDFM8+3afrO6eYwJBn9ZAhDOzG3L+/9llab/haCARS2UIfffmOurYLwbgDRs8n0rfr6qAAPEAuAQw==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/fast-fifo": {
       "version": "1.3.2",
@@ -3097,7 +3149,6 @@
       "version": "2.0.5",
       "resolved": "https://registry.npmjs.org/get-caller-file/-/get-caller-file-2.0.5.tgz",
       "integrity": "sha512-DyFP3BM/3YHTQOCUL/w0OZHR0lpKeGrxotcHWcqNEdnltqFwXVfhEBQ94eIo34AfQpo0rGki4cyIiftY06h2Fg==",
-      "dev": true,
       "license": "ISC",
       "engines": {
         "node": "6.* || 8.* || >= 10.*"
@@ -3253,6 +3304,13 @@
       "engines": {
         "node": ">= 0.4"
       }
+    },
+    "node_modules/help-me": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/help-me/-/help-me-5.0.0.tgz",
+      "integrity": "sha512-7xgomUX6ADmcYzFik0HzAxh/73YlKR9bmFzf51CZwR+b6YtzU2m0u49hQCqV6SvlqIqsaxovfwdvbnsw3b/zpg==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/html-escaper": {
       "version": "2.0.2",
@@ -4098,6 +4156,16 @@
         "url": "https://github.com/chalk/supports-color?sponsor=1"
       }
     },
+    "node_modules/joycon": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/joycon/-/joycon-3.1.1.tgz",
+      "integrity": "sha512-34wB/Y7MW7bzjKRjUKTa46I2Z7eV62Rkhva+KkopW7Qvv/OSWBqvkSY7vusOPrNuZcUG3tApvdVgNB8POj3SPw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
+      }
+    },
     "node_modules/js-tokens": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz",
@@ -4429,6 +4497,16 @@
         "url": "https://github.com/sponsors/isaacs"
       }
     },
+    "node_modules/minimist": {
+      "version": "1.2.8",
+      "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.8.tgz",
+      "integrity": "sha512-2yyAR8qBkN3YuheJanUpWC5U3bb5osDywNB8RzDVlDwDHbocAJveqqj1u8+SVD7jkWT4yvsHCpWqqWqAxb0zCA==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
     "node_modules/minipass": {
       "version": "7.1.3",
       "resolved": "https://registry.npmjs.org/minipass/-/minipass-7.1.3.tgz",
@@ -4721,6 +4799,15 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/on-exit-leak-free": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/on-exit-leak-free/-/on-exit-leak-free-2.1.2.tgz",
+      "integrity": "sha512-0eJJY6hXLGf1udHwfNftBqH+g73EU4B504nZeKpz1sYRKafAghwxEJunB2O7rDZkL4PGfsMVnTXZ2EjibbqcsA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
     "node_modules/on-finished": {
       "version": "2.4.1",
       "resolved": "https://registry.npmjs.org/on-finished/-/on-finished-2.4.1.tgz",
@@ -4939,6 +5026,93 @@
         "url": "https://github.com/sponsors/jonschlinkert"
       }
     },
+    "node_modules/pino": {
+      "version": "10.3.1",
+      "resolved": "https://registry.npmjs.org/pino/-/pino-10.3.1.tgz",
+      "integrity": "sha512-r34yH/GlQpKZbU1BvFFqOjhISRo1MNx1tWYsYvmj6KIRHSPMT2+yHOEb1SG6NMvRoHRF0a07kCOox/9yakl1vg==",
+      "license": "MIT",
+      "dependencies": {
+        "@pinojs/redact": "^0.4.0",
+        "atomic-sleep": "^1.0.0",
+        "on-exit-leak-free": "^2.1.0",
+        "pino-abstract-transport": "^3.0.0",
+        "pino-std-serializers": "^7.0.0",
+        "process-warning": "^5.0.0",
+        "quick-format-unescaped": "^4.0.3",
+        "real-require": "^0.2.0",
+        "safe-stable-stringify": "^2.3.1",
+        "sonic-boom": "^4.0.1",
+        "thread-stream": "^4.0.0"
+      },
+      "bin": {
+        "pino": "bin.js"
+      }
+    },
+    "node_modules/pino-abstract-transport": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/pino-abstract-transport/-/pino-abstract-transport-3.0.0.tgz",
+      "integrity": "sha512-wlfUczU+n7Hy/Ha5j9a/gZNy7We5+cXp8YL+X+PG8S0KXxw7n/JXA3c46Y0zQznIJ83URJiwy7Lh56WLokNuxg==",
+      "license": "MIT",
+      "dependencies": {
+        "split2": "^4.0.0"
+      }
+    },
+    "node_modules/pino-http": {
+      "version": "11.0.0",
+      "resolved": "https://registry.npmjs.org/pino-http/-/pino-http-11.0.0.tgz",
+      "integrity": "sha512-wqg5XIAGRRIWtTk8qPGxkbrfiwEWz1lgedVLvhLALudKXvg1/L2lTFgTGPJ4Z2e3qcRmxoFxDuSdMdMGNM6I1g==",
+      "license": "MIT",
+      "dependencies": {
+        "get-caller-file": "^2.0.5",
+        "pino": "^10.0.0",
+        "pino-std-serializers": "^7.0.0",
+        "process-warning": "^5.0.0"
+      }
+    },
+    "node_modules/pino-pretty": {
+      "version": "13.1.3",
+      "resolved": "https://registry.npmjs.org/pino-pretty/-/pino-pretty-13.1.3.tgz",
+      "integrity": "sha512-ttXRkkOz6WWC95KeY9+xxWL6AtImwbyMHrL1mSwqwW9u+vLp/WIElvHvCSDg0xO/Dzrggz1zv3rN5ovTRVowKg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "colorette": "^2.0.7",
+        "dateformat": "^4.6.3",
+        "fast-copy": "^4.0.0",
+        "fast-safe-stringify": "^2.1.1",
+        "help-me": "^5.0.0",
+        "joycon": "^3.1.1",
+        "minimist": "^1.2.6",
+        "on-exit-leak-free": "^2.1.0",
+        "pino-abstract-transport": "^3.0.0",
+        "pump": "^3.0.0",
+        "secure-json-parse": "^4.0.0",
+        "sonic-boom": "^4.0.1",
+        "strip-json-comments": "^5.0.2"
+      },
+      "bin": {
+        "pino-pretty": "bin.js"
+      }
+    },
+    "node_modules/pino-pretty/node_modules/strip-json-comments": {
+      "version": "5.0.3",
+      "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-5.0.3.tgz",
+      "integrity": "sha512-1tB5mhVo7U+ETBKNf92xT4hrQa3pm0MZ0PQvuDnWgAAGHDsfp4lPSpiS6psrSiet87wyGPh9ft6wmhOMQ0hDiw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=14.16"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/pino-std-serializers": {
+      "version": "7.1.0",
+      "resolved": "https://registry.npmjs.org/pino-std-serializers/-/pino-std-serializers-7.1.0.tgz",
+      "integrity": "sha512-BndPH67/JxGExRgiX1dX0w1FvZck5Wa4aal9198SrRhZjH3GxKQUKIBnYJTdj2HDN3UQAS06HlfcSbQj2OHmaw==",
+      "license": "MIT"
+    },
     "node_modules/pirates": {
       "version": "4.0.7",
       "resolved": "https://registry.npmjs.org/pirates/-/pirates-4.0.7.tgz",
@@ -4991,6 +5165,22 @@
         "url": "https://github.com/chalk/ansi-styles?sponsor=1"
       }
     },
+    "node_modules/process-warning": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/process-warning/-/process-warning-5.0.0.tgz",
+      "integrity": "sha512-a39t9ApHNx2L4+HBnQKqxxHNs1r7KF+Intd8Q/g1bUh6q0WIp9voPXJ/x0j+ZL45KF1pJd9+q2jLIRMfvEshkA==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/fastify"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/fastify"
+        }
+      ],
+      "license": "MIT"
+    },
     "node_modules/proxy-addr": {
       "version": "2.0.7",
       "resolved": "https://registry.npmjs.org/proxy-addr/-/proxy-addr-2.0.7.tgz",
@@ -5002,6 +5192,17 @@
       },
       "engines": {
         "node": ">= 0.10"
+      }
+    },
+    "node_modules/pump": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/pump/-/pump-3.0.4.tgz",
+      "integrity": "sha512-VS7sjc6KR7e1ukRFhQSY5LM2uBWAUPiOPa/A3mkKmiMwSmRFUITt0xuj+/lesgnCv+dPIEYlkzrcyXgquIHMcA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "end-of-stream": "^1.1.0",
+        "once": "^1.3.1"
       }
     },
     "node_modules/punycode": {
@@ -5045,6 +5246,12 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/quick-format-unescaped": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/quick-format-unescaped/-/quick-format-unescaped-4.0.4.tgz",
+      "integrity": "sha512-tYC1Q1hgyRuHgloV/YXs2w15unPVh8qfu/qCTfhTYamaw7fyhumKa2yGpdSo87vY32rIclj+4fWYQXUMs9EHvg==",
+      "license": "MIT"
+    },
     "node_modules/range-parser": {
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/range-parser/-/range-parser-1.2.1.tgz",
@@ -5084,6 +5291,15 @@
       "integrity": "sha512-XjBR15BhXuylgWGuslhDKqlSayuqvqBX91BP8pauG8kd1zY8kotkNWbXksTCNRarse4kuGbe2kIY05ARtwNIvw==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/real-require": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/real-require/-/real-require-0.2.0.tgz",
+      "integrity": "sha512-57frrGM/OCTLqLOAh0mhVA9VBMHd+9U7Zb2THMGdBUoZVOtGbJzjxsYGDJ3A9AYYCP4hn6y1TVbaOfzWtm5GFg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 12.13.0"
+      }
     },
     "node_modules/require-directory": {
       "version": "2.1.1",
@@ -5154,11 +5370,37 @@
       ],
       "license": "MIT"
     },
+    "node_modules/safe-stable-stringify": {
+      "version": "2.5.0",
+      "resolved": "https://registry.npmjs.org/safe-stable-stringify/-/safe-stable-stringify-2.5.0.tgz",
+      "integrity": "sha512-b3rppTKm9T+PsVCBEOUR46GWI7fdOs00VKZ1+9c1EWDaDMvjQc6tUwuFyIprgGgTcWoVHSKrU8H31ZHA2e0RHA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
+      }
+    },
     "node_modules/safer-buffer": {
       "version": "2.1.2",
       "resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
       "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==",
       "license": "MIT"
+    },
+    "node_modules/secure-json-parse": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/secure-json-parse/-/secure-json-parse-4.1.0.tgz",
+      "integrity": "sha512-l4KnYfEyqYJxDwlNVyRfO2E4NTHfMKAWdUuA8J0yve2Dz/E/PdBepY03RvyJpssIpRFwJoCD55wA+mEDs6ByWA==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/fastify"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/fastify"
+        }
+      ],
+      "license": "BSD-3-Clause"
     },
     "node_modules/semver": {
       "version": "7.8.0",
@@ -5347,6 +5589,15 @@
         "node": ">=8"
       }
     },
+    "node_modules/sonic-boom": {
+      "version": "4.2.1",
+      "resolved": "https://registry.npmjs.org/sonic-boom/-/sonic-boom-4.2.1.tgz",
+      "integrity": "sha512-w6AxtubXa2wTXAUsZMMWERrsIRAdrK0Sc+FUytWvYAhBJLyuI4llrMIC1DtlNSdI99EI86KZum2MMq3EAZlF9Q==",
+      "license": "MIT",
+      "dependencies": {
+        "atomic-sleep": "^1.0.0"
+      }
+    },
     "node_modules/source-map": {
       "version": "0.6.1",
       "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
@@ -5375,6 +5626,15 @@
       "license": "MIT",
       "dependencies": {
         "memory-pager": "^1.0.2"
+      }
+    },
+    "node_modules/split2": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/split2/-/split2-4.2.0.tgz",
+      "integrity": "sha512-UcjcJOWknrNkF6PLX83qcHM6KHgVKNkV62Y8a5uYDVv9ydGQVwAHMKqHdJje1VTWpljG0WYpCDhrCdAOYH4TWg==",
+      "license": "ISC",
+      "engines": {
+        "node": ">= 10.x"
       }
     },
     "node_modules/sprintf-js": {
@@ -5750,6 +6010,24 @@
       "dependencies": {
         "b4a": "^1.6.4"
       }
+    },
+    "node_modules/thread-stream": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/thread-stream/-/thread-stream-4.2.0.tgz",
+      "integrity": "sha512-e2zZ96wSChazBsbENf/Pcm/4swHt2cEKQ92rhUjkL9GCKiTDJIaTBenjE/m9DXi0QBmTMDkFDdOomUy20A1tDQ==",
+      "license": "MIT",
+      "dependencies": {
+        "real-require": "^1.0.0"
+      },
+      "engines": {
+        "node": ">=20"
+      }
+    },
+    "node_modules/thread-stream/node_modules/real-require": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/real-require/-/real-require-1.0.0.tgz",
+      "integrity": "sha512-P4nbQYQfePJxRSmY+v/KINxVucm4NF3p3s7pJveMTtom52FR4YGltUQLB8idDXwDDWW+eYrWDFbuzUnjoWHF7g==",
+      "license": "MIT"
     },
     "node_modules/tmpl": {
       "version": "1.0.5",

--- a/be/package.json
+++ b/be/package.json
@@ -21,11 +21,14 @@
     "dotenv": "^17.2.3",
     "express": "^5.2.1",
     "jsonwebtoken": "^9.0.3",
-    "mongoose": "^9.0.2"
+    "mongoose": "^9.0.2",
+    "pino": "^10.3.1",
+    "pino-http": "^11.0.0"
   },
   "devDependencies": {
     "jest": "^30.4.2",
     "mongodb-memory-server": "^11.2.0",
+    "pino-pretty": "^13.1.3",
     "supertest": "^7.2.2"
   }
 }

--- a/be/src/app.js
+++ b/be/src/app.js
@@ -9,11 +9,31 @@ const corsOptions = {
   origin: process.env.FRONTEND_URL || 'http://localhost:5173',
   credentials: true,
 };
+const pinoHttp = require('pino-http');
+const logger = require('./utils/logger');
+const errorHandler = require('./middleware/errorHandler');
 
 app.use(cors(corsOptions));
 app.use(express.json());
+app.use(pinoHttp({
+  logger,
+  customLogLevel: (req, res, err) => {
+    if (res.statusCode >= 500 || err) return 'error';
+    if (res.statusCode >= 400) return 'warn';
+    return 'info';
+  },
+  customProps: (req, res) => ({
+    method: req.method,
+    path: req.path,
+    statusCode: res.statusCode,
+  }),
+  customAttributeKeys: {
+    responseTime: 'latencyMs',
+  },
+}));
 
 app.use('/api/auth', authController);
 app.use('/api', storiesRoutes);
+app.use(errorHandler);
 
 module.exports = app;

--- a/be/src/controller/authController.js
+++ b/be/src/controller/authController.js
@@ -3,21 +3,22 @@ const bcrypt = require('bcrypt');
 const jwt = require('jsonwebtoken');
 const User = require('../models/userModel');
 const auth = require('../middleware/authMiddleware');
+const APIError = require('../utils/APIError');
 
 const router = express.Router();
 
-router.post('/register', async (req, res) => {
+router.post('/register', async (req, res, next) => {
   const { username, email, password } = req.body;
   const normalizedEmail = String(email || '').trim().toLowerCase();
 
   try {
     if (!username || !normalizedEmail || !password) {
-      return res.status(400).json({ message: 'All fields are required' });
+      throw new APIError(400, 'VALIDATION_ERROR', 'Username, email, and password are required');
     }
 
     const userExists = await User.findOne({ email: normalizedEmail });
     if (userExists) {
-      return res.status(400).json({ message: 'User already exists' });
+      throw new APIError(400, 'USER_EXISTS', 'User already exists');
     }
 
     const newUser = await User.create({ username, email: normalizedEmail, password, role: 'user' });
@@ -26,18 +27,18 @@ router.post('/register', async (req, res) => {
 
     return res.status(201).json({ message: 'User registered successfully', user: userResponse });
   } catch (err) {
-    return res.status(500).json({ message: 'Server error!' });
+    return next(err);
   }
 });
 
-router.post('/login', async (req, res) => {
+router.post('/login', async (req, res, next) => {
   const { username, email, password } = req.body;
   const normalizedEmail = String(email || '').trim().toLowerCase();
   const normalizedUsername = String(username || '').trim();
 
   try {
     if (!password || (!normalizedEmail && !normalizedUsername)) {
-      return res.status(400).json({ message: 'Credentials required' });
+      throw new APIError(400, 'VALIDATION_ERROR', 'Credentials required');
     }
 
     const query = normalizedEmail
@@ -45,19 +46,16 @@ router.post('/login', async (req, res) => {
       : { username: normalizedUsername };
     const user = await User.findOne(query);
     if (!user) {
-      return res.status(400).json({ message: 'Invalid credentials' });
+      throw new APIError(400, 'INVALID_CREDENTIALS', 'Invalid credentials');
     }
 
     if (user.isBanned) {
-      return res.status(403).json({
-        message: user.banReason ? `Account is banned: ${user.banReason}` : 'Account is banned',
-        code: 'USER_BANNED',
-      });
+      throw new APIError(403, 'USER_BANNED', user.banReason ? `Account is banned: ${user.banReason}` : 'Account is banned');
     }
 
     const isMatch = await bcrypt.compare(password, user.password);
     if (!isMatch) {
-      return res.status(400).json({ message: 'Invalid credentials' });
+      throw new APIError(400, 'INVALID_CREDENTIALS', 'Invalid credentials');
     }
 
     const userResponse = user.toObject();
@@ -71,17 +69,17 @@ router.post('/login', async (req, res) => {
 
     return res.json({ message: 'Login successful', token, user: userResponse });
   } catch (err) {
-    return res.status(500).json({ message: 'Server error' });
+    return next(err);
   }
 });
 
-router.get('/me', auth, async (req, res) => {
+router.get('/me', auth, async (req, res, next) => {
   try {
     const user = await User.findById(req.userId).select('-password');
-    if (!user) return res.status(404).json({ message: 'User not found' });
+    if (!user) throw new APIError(404, 'USER_NOT_FOUND', 'User not found');
     return res.json({ user });
   } catch (err) {
-    return res.status(500).json({ message: 'Server error' });
+    return next(err);
   }
 });
 

--- a/be/src/controller/storiesController.js
+++ b/be/src/controller/storiesController.js
@@ -1,55 +1,56 @@
 const storiesService = require('../services/storiesService');
+const APIError = require('../utils/APIError');
 
 const CREATABLE_STORY_TYPES = new Set(['story', 'job', 'poll']);
 const FEED_TYPES = new Set(['top', 'new', 'best', 'ask', 'show', 'job']);
 
-async function getStories(req, res) {
+async function getStories(req, res, next) {
   const { type } = req.params;
-  if (!FEED_TYPES.has(type)) {
-    return res.status(400).json({ message: 'Invalid story type' });
-  }
-
-  const limit = Math.min(Math.max(parseInt(req.query.limit, 10) || 30, 1), 100);
-  const page = Math.max(parseInt(req.query.page, 10) || 1, 1);
 
   try {
+    if (!FEED_TYPES.has(type)) {
+      throw new APIError(400, 'VALIDATION_ERROR', 'Invalid story type');
+    }
+
+    const limit = Math.min(Math.max(parseInt(req.query.limit, 10) || 30, 1), 100);
+    const page = Math.max(parseInt(req.query.page, 10) || 1, 1);
     const stories = await storiesService.getStories(type, page, limit);
     return res.json(stories);
   } catch (err) {
-    return res.status(500).json({ message: 'Failed to read stories' });
+    return next(err);
   }
 }
 
-async function getItem(req, res) {
+async function getItem(req, res, next) {
   const id = req.params.id;
   
   try {
     const item = await storiesService.getItemWithComments(id);
     if (!item) {
-      return res.status(404).json({ message: `Item ${id} not found` });
+      throw new APIError(404, 'NOT_FOUND', `Item ${id} not found`);
     }
 
     return res.json(item);
   } catch (err) {
-    return res.status(500).json({ message: 'Failed to read item' });
+    return next(err);
   }
 }
 
-async function createStory(req, res) {
+async function createStory(req, res, next) {
   const { title, url, text, type = 'story' } = req.body || {};
 
-  if (!title || typeof title !== 'string' || !title.trim()) {
-    return res.status(400).json({ message: 'Title is required' });
-  }
-
-  if (!CREATABLE_STORY_TYPES.has(type)) {
-    return res.status(400).json({ message: 'Invalid story type' });
-  }
-  if (!url && !text) {
-    return res.status(400).json({ message: 'Either url or text is required' });
-  }
-
   try {
+    if (!title || typeof title !== 'string' || !title.trim()) {
+      throw new APIError(400, 'VALIDATION_ERROR', 'Title is required');
+    }
+
+    if (!CREATABLE_STORY_TYPES.has(type)) {
+      throw new APIError(400, 'VALIDATION_ERROR', 'Invalid story type');
+    }
+    if (!url && !text) {
+      throw new APIError(400, 'VALIDATION_ERROR', 'Either url or text is required');
+    }
+
     const story = await storiesService.createStory({
         title,
         url,
@@ -59,22 +60,22 @@ async function createStory(req, res) {
     });
     return res.status(201).json(story);
   } catch (err) {
-    return res.status(500).json({ message: 'Failed to create story' });
+    return next(err);
   }
 }
 
-async function createComment(req, res) {
+async function createComment(req, res, next) {
   const { text, parent_id: parentId, root_id: rootId } = req.body || {};
 
-  if (!text || typeof text !== 'string' || !text.trim()) {
-    return res.status(400).json({ message: 'Comment text is required' });
-  }
-
-  if (!parentId) {
-    return res.status(400).json({ message: 'Parent ID is required' });
-  }
-
   try {
+    if (!text || typeof text !== 'string' || !text.trim()) {
+      throw new APIError(400, 'VALIDATION_ERROR', 'Comment text is required');
+    }
+
+    if (!parentId) {
+      throw new APIError(400, 'VALIDATION_ERROR', 'Parent ID is required');
+    }
+
     const comment = await storiesService.createComment({
         text,
         parentId,
@@ -83,8 +84,7 @@ async function createComment(req, res) {
     });
     return res.status(201).json(comment);
   } catch (err) {
-    console.error('[CreateComment Error]:', err);
-    return res.status(500).json({ message: 'Failed to create comment', error: err.message });
+    return next(err);
   }
 }
 

--- a/be/src/middleware/authMiddleware.js
+++ b/be/src/middleware/authMiddleware.js
@@ -1,5 +1,6 @@
 const jwt = require('jsonwebtoken');
 const User = require('../models/userModel');
+const APIError = require('../utils/APIError');
 
 module.exports = async function authMiddleware(req, res, next) {
   try {
@@ -7,22 +8,22 @@ module.exports = async function authMiddleware(req, res, next) {
     const [type, token] = header.split(' ');
 
     if (type !== 'Bearer' || !token) {
-      return res.status(401).json({ message: 'Missing or invalid Authorization header' });
+      throw new APIError(401, 'UNAUTHORIZED', 'Missing or invalid Authorization header');
     }
 
     const decoded = jwt.verify(token, process.env.JWT_SECRET);
     const userId = decoded?.id || decoded?.userId || decoded?._id;
     if (!userId) {
-      return res.status(401).json({ message: 'Invalid token payload' });
+      throw new APIError(401, 'UNAUTHORIZED', 'Invalid token payload');
     }
 
     const user = await User.findById(userId).select('username role isBanned');
     if (!user) {
-      return res.status(401).json({ message: 'User not found' });
+      throw new APIError(401, 'UNAUTHORIZED', 'User not found');
     }
 
     if (user.isBanned) {
-      return res.status(403).json({ message: 'Account is banned', code: 'USER_BANNED' });
+      throw new APIError(403, 'USER_BANNED', 'Account is banned');
     }
 
     req.userId = userId;
@@ -34,6 +35,11 @@ module.exports = async function authMiddleware(req, res, next) {
 
     return next();
   } catch (err) {
-    return res.status(401).json({ message: 'Invalid or expired token' });
+    if (err instanceof APIError) {
+      return next(err);
+    }
+
+    return next(new APIError(401, 'UNAUTHORIZED', 'Invalid or expired token'));
+
   }
 };

--- a/be/src/middleware/errorHandler.js
+++ b/be/src/middleware/errorHandler.js
@@ -1,0 +1,31 @@
+const APIError = require('../utils/APIError');
+const logger = require('../utils/logger');
+
+function errorHandler(err, req, res, next) {
+    if (res.headersSent) {
+        return next(err);
+    }
+
+    const isKnownError = err instanceof APIError;
+    const statusCode = isKnownError ? err.statusCode : 500;
+    const code = isKnownError ? err.code : 'INTERNAL_SERVER_ERROR';
+    const message = isKnownError ? err.message : 'Internal server error';
+
+    if (statusCode >= 500) {
+        logger.error({ err, method: req.method, path: req.originalUrl }, message);
+    }
+
+    const payload = {
+        status: 'error',
+        code,
+        message,
+    };
+
+    if (process.env.NODE_ENV !== 'production' && err.stack) {
+        payload.stack = err.stack;
+    }
+
+    return res.status(statusCode).json(payload);
+}
+
+module.exports = errorHandler;

--- a/be/src/utils/APIError.js
+++ b/be/src/utils/APIError.js
@@ -1,0 +1,12 @@
+//generate a custom error class for API errors
+class APIError extends Error {
+    constructor(statusCode, code, message) {
+        super(message);
+        this.name = 'APIError';
+        this.statusCode = statusCode;
+        this.code = code;
+        Error.captureStackTrace(this, APIError);
+    }
+}
+
+module.exports = APIError;

--- a/be/src/utils/logger.js
+++ b/be/src/utils/logger.js
@@ -1,0 +1,21 @@
+const pino = require('pino');
+
+const isProduction = process.env.NODE_ENV === 'production';
+const isTest = process.env.NODE_ENV === 'test';
+
+const options = {
+    level: isTest ? 'silent' : process.env.LOG_LEVEL || 'info',
+};
+
+if (!isProduction && !isTest) {
+    options.transport = {
+        target: 'pino-pretty',
+        options: {
+            colorize: true,
+            translateTime: 'SYS:standard',
+            ignore: 'pid,hostname',
+        },
+    };
+}
+
+module.exports = pino(options);

--- a/be/tests/auth.test.js
+++ b/be/tests/auth.test.js
@@ -36,10 +36,27 @@ describe('Auth Endpoints', () => {
         username: 'newuser',
         email: 'test@example.com',
         password: 'password123'
-      });
+    });
     
     expect(res.statusCode).toEqual(400);
-    expect(res.body.message).toEqual('User already exists');
+    expect(res.body).toMatchObject({
+      status: 'error',
+      code: 'USER_EXISTS',
+      message: 'User already exists',
+    });
+  });
+
+  it('should return a structured error for missing credentials', async () => {
+    const res = await request(app)
+      .post('/api/auth/login')
+      .send({});
+
+    expect(res.statusCode).toEqual(400);
+    expect(res.body).toMatchObject({
+      status: 'error',
+      code: 'VALIDATION_ERROR',
+      message: 'Credentials required',
+    });
   });
 
   it('should login an existing user', async () => {
@@ -60,5 +77,16 @@ describe('Auth Endpoints', () => {
 
     expect(res.statusCode).toEqual(200);
     expect(res.body).toHaveProperty('token');
+  });
+
+  it('should return a structured error for protected routes without auth', async () => {
+    const res = await request(app).get('/api/auth/me');
+
+    expect(res.statusCode).toEqual(401);
+    expect(res.body).toMatchObject({
+      status: 'error',
+      code: 'UNAUTHORIZED',
+      message: 'Missing or invalid Authorization header',
+    });
   });
 });

--- a/be/tests/error-handler.test.js
+++ b/be/tests/error-handler.test.js
@@ -1,0 +1,51 @@
+const express = require('express');
+const request = require('supertest');
+const APIError = require('../src/utils/APIError');
+const errorHandler = require('../src/middleware/errorHandler');
+
+function buildApp(routeHandler) {
+  const app = express();
+  app.get('/test', routeHandler);
+  app.use(errorHandler);
+  return app;
+}
+
+describe('errorHandler', () => {
+  const originalNodeEnv = process.env.NODE_ENV;
+
+  afterEach(() => {
+    process.env.NODE_ENV = originalNodeEnv;
+  });
+
+  it('formats APIError responses with status, code, and message', async () => {
+    const app = buildApp((req, res, next) => {
+      next(new APIError(404, 'NOT_FOUND', 'Resource not found'));
+    });
+
+    const res = await request(app).get('/test');
+
+    expect(res.statusCode).toBe(404);
+    expect(res.body).toMatchObject({
+      status: 'error',
+      code: 'NOT_FOUND',
+      message: 'Resource not found',
+    });
+  });
+
+  it('hides raw stack traces from production error responses', async () => {
+    process.env.NODE_ENV = 'production';
+
+    const app = buildApp((req, res, next) => {
+      next(new Error('Database exploded'));
+    });
+
+    const res = await request(app).get('/test');
+
+    expect(res.statusCode).toBe(500);
+    expect(res.body).toEqual({
+      status: 'error',
+      code: 'INTERNAL_SERVER_ERROR',
+      message: 'Internal server error',
+    });
+  });
+});


### PR DESCRIPTION
## Summary

Closes #40.

This PR adds structured backend logging with Pino and introduces a shared API error handling flow.

## Changes

- Add `pino`, `pino-http`, and `pino-pretty`
- Add centralized logger utility in `be/src/utils/logger.js`
- Register `pino-http` middleware to log request method, path, status code, and latency
- Add `APIError` for structured application errors
- Add global `errorHandler` middleware
- Refactor auth and stories error paths to use `APIError` and `next(err)`
- Replace inline API error responses with a consistent response format:
  ```json
  {
    "status": "error",
    "code": "...",
    "message": "..."
  }
